### PR TITLE
Fix the max value of uint16 in a example doc

### DIFF
--- a/notebooks/example_16_bit_tiff.ipynb
+++ b/notebooks/example_16_bit_tiff.ipynb
@@ -111,7 +111,7 @@
     "- `np.uint8`, an unsigned 8-bit integer that can define values between 0 and 255.\n",
     "- `np.float32`, a floating-point number with single precision. For `np.float32` input, Albumentations expects that value will lie in the range between 0.0 and 1.0.\n",
     "\n",
-    "Albumentations has a dedicated transformation called `ToFloat` that takes a NumPy array with data types such as `np.uint16`, `np.uint32`, etc. (so any datatype that used values higher than 255 to represent pixel intensity) and converts it to a NumPy array with the `np.float32` datatype. Additionally, this transformation divides all input values to lie in the range `[0.0, 1.0]`. By default, if the input data type is `np.uint16`, all values are divided by 65536, and if the input data type is `np.uint32`, all values are divided by 4294967295. You can specify your divider in the `max_value` parameter.\n",
+    "Albumentations has a dedicated transformation called `ToFloat` that takes a NumPy array with data types such as `np.uint16`, `np.uint32`, etc. (so any datatype that used values higher than 255 to represent pixel intensity) and converts it to a NumPy array with the `np.float32` datatype. Additionally, this transformation divides all input values to lie in the range `[0.0, 1.0]`. By default, if the input data type is `np.uint16`, all values are divided by 65535, and if the input data type is `np.uint32`, all values are divided by 4294967295. You can specify your divider in the `max_value` parameter.\n",
     "\n",
     "The augmentation pipeline for non-8-bit images consists of the following stages:\n",
     "\n",


### PR DESCRIPTION
The max value of uint16 is introduced as 65536 in this ipynb document, but it seems to be 65535.