### PR TITLE
notebooks: Fix dataset naming typo

### DIFF
--- a/notebooks/pytorch_classification.ipynb
+++ b/notebooks/pytorch_classification.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example shows how to use Albumentations for image classification. We will use the [`Cats vs. Docs` dataset](https://www.kaggle.com/shaunthesheep/microsoft-catsvsdogs-dataset). The task will be to detect whether an image contains a cat or a dog."
+    "This example shows how to use Albumentations for image classification. We will use the [`Cats vs. Dogs` dataset](https://www.kaggle.com/shaunthesheep/microsoft-catsvsdogs-dataset). The task will be to detect whether an image contains a cat or a dog."
    ]
   },
   {
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Download and extract the `Cats vs. Docs` dataset"
+    "### Download and extract the `Cats vs. Dogs` dataset"
    ]
   },
   {


### PR DESCRIPTION
This MR fixes the dataset `Cats vs Dogs` naming typo ([link to dataset](https://www.kaggle.com/datasets/shaunthesheep/microsoft-catsvsdogs-dataset/data)).