### PR TITLE
fix(docs): update stale albumentations docs links

### DIFF
--- a/notebooks/example_bboxes.ipynb
+++ b/notebooks/example_bboxes.ipynb
@@ -130,7 +130,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Coordinates for those bounding boxes are declared using the `coco` format. Each bounding box is described using four values `[x_min, y_min, width, height]`. For the detailed description of different formats for bounding boxes coordinates, please refer to the documentation article about bounding boxes - https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/."
+    "Coordinates for those bounding boxes are declared using the `coco` format. Each bounding box is described using four values `[x_min, y_min, width, height]`. For the detailed description of different formats for bounding boxes coordinates, please refer to the documentation article about bounding boxes - https://albumentations.ai/docs/3-basic-usage/bounding-boxes-augmentations/."
    ]
   },
   {
@@ -185,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To make an augmentation pipeline that works with bounding boxes, you need to pass an instance of `BboxParams` to `Compose`. In `BboxParams` you need to specify the format of coordinates for bounding boxes and optionally a few other parameters. For the detailed description of `BboxParams` please refer to the documentation article about bounding boxes - https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/."
+    "To make an augmentation pipeline that works with bounding boxes, you need to pass an instance of `BboxParams` to `Compose`. In `BboxParams` you need to specify the format of coordinates for bounding boxes and optionally a few other parameters. For the detailed description of `BboxParams` please refer to the documentation article about bounding boxes - https://albumentations.ai/docs/3-basic-usage/bounding-boxes-augmentations/."
    ]
   },
   {

--- a/notebooks/example_bboxes2.ipynb
+++ b/notebooks/example_bboxes2.ipynb
@@ -137,7 +137,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Coordinates for those bounding boxes are declared using the `coco` format. Each bounding box is described using four values `[x_min, y_min, width, height]`. For the detailed description of different formats for bounding boxes coordinates, please refer to the documentation article about bounding boxes - https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/."
+    "Coordinates for those bounding boxes are declared using the `coco` format. Each bounding box is described using four values `[x_min, y_min, width, height]`. For the detailed description of different formats for bounding boxes coordinates, please refer to the documentation article about bounding boxes - https://albumentations.ai/docs/3-basic-usage/bounding-boxes-augmentations/."
    ]
   },
   {

--- a/notebooks/example_keypoints.ipynb
+++ b/notebooks/example_keypoints.ipynb
@@ -11,14 +11,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will show how to apply Albumentations to the keypoint augmentation problem. Please refer to [A list of transforms and their supported targets](https://albumentations.ai/docs/getting_started/transforms_and_targets/#spatial-level-transforms) to see which spatial-level augmentations support keypoints. You can use any pixel-level augmentation to an image with keypoints because pixel-level augmentations don't affect keypoints."
+    "In this notebook we will show how to apply Albumentations to the keypoint augmentation problem. Please refer to [A list of transforms and their supported targets](https://albumentations.ai/docs/reference/supported-targets-by-transform/#spatial-level-dual-transforms) to see which spatial-level augmentations support keypoints. You can use any pixel-level augmentation to an image with keypoints because pixel-level augmentations don't affect keypoints."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: by default, augmentations that work with keypoints don't change keypoints' labels after transformation. If keypoints' labels are side-specific, that may pose a problem. For example, if you have a keypoint named `left arm` and apply a HorizontalFlip augmentation, you will get a keypoint with the same `left arm` label, but it will now look like a `right arm` keypoint. See a picture at the end of [this article](https://albumentations.ai/docs/getting_started/keypoints_augmentation/) for a visual example.\n",
+    "**Note**: by default, augmentations that work with keypoints don't change keypoints' labels after transformation. If keypoints' labels are side-specific, that may pose a problem. For example, if you have a keypoint named `left arm` and apply a HorizontalFlip augmentation, you will get a keypoint with the same `left arm` label, but it will now look like a `right arm` keypoint. See a picture at the end of [this article](https://albumentations.ai/docs/3-basic-usage/keypoint-augmentations/) for a visual example.\n",
     "\n",
     "If you work with such type of keypoints, consider using SymmetricKeypoints augmentations from [albumentations-experimental](https://github.com/albumentations-team/albumentations_experimental#spatial-level-transforms) that are created precisely to handle that case."
    ]
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will use the `xy` format for keypoints' coordinates. Each keypoint is defined with two coordinates, `x` is the position on the x-axis, and `y` is the position on the y-axis. Please refer to this article with the detailed description of formats for keypoints' coordinates - <a href='https://albumentations.ai/docs/getting_started/keypoints_augmentation/' target='_blank'>https://albumentations.ai/docs/getting_started/keypoints_augmentation/</a>"
+    "We will use the `xy` format for keypoints' coordinates. Each keypoint is defined with two coordinates, `x` is the position on the x-axis, and `y` is the position on the y-axis. Please refer to this article with the detailed description of formats for keypoints' coordinates - <a href='https://albumentations.ai/docs/3-basic-usage/keypoint-augmentations/' target='_blank'>https://albumentations.ai/docs/3-basic-usage/keypoint-augmentations/</a>"
    ]
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Update Albumentations documentation links in example notebooks to point to the current keypoints and bounding boxes docs pages.

Documentation:
- Refresh keypoints-related links in example_keypoints.ipynb to the new supported-targets and keypoint augmentations documentation pages.
- Refresh bounding-box-related links in example_bboxes.ipynb and example_bboxes2.ipynb to the new bounding boxes augmentations documentation page.